### PR TITLE
fix action schedule

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: [ "master" ]
   schedule:
-    - cron: '0 13 * * *' # 13:00 server time, meaning 14/15:00 our time. For regular commits in LS. GitHub seems to be quite busy at that time, so this might be executed much later
-    - cron: '0 7 * * *'  # 07:00 server time, meaning 08/09:00 our time. For the night owls and early birds.
+    - cron: '0 13 * * 1' 
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adjusts the interval of the cron job of the pro samples action. The initial idea was to have an accurate idea which change in LS breaks a sample. However, this requires immediate fixing of broken samples, which didn't happen, so now all this does is spamming. The new interval should cause much less spam now while maintaining a similarly reasonable interval as our developer hub samples