### PR TITLE
fix ELB test

### DIFF
--- a/elb-load-balancing/Makefile
+++ b/elb-load-balancing/Makefile
@@ -1,7 +1,6 @@
 export AWS_ACCESS_KEY_ID ?= test
 export AWS_SECRET_ACCESS_KEY ?= test
 export AWS_DEFAULT_REGION = us-east-1
-export SERVICES = serverless,events,cognito
 
 usage:       ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'


### PR DESCRIPTION
This PR removes the `SERVICES` env variable because of which the tests were failing.

```bash
2024-05-17T16:01:25.5622666Z Deploying test-elb-load-balancing to stage local (us-east-1)
2024-05-17T16:01:51.7086321Z Creating deployment bucket 'testbucket'...
2024-05-17T16:02:13.6540218Z 
2024-05-17T16:02:13.6541103Z -------- Deployment Bucket Error --------
2024-05-17T16:02:13.6544376Z Service 's3' is not enabled. Please check your 'SERVICES' configuration variable.
2024-05-17T16:02:41.1070848Z Creating deployment bucket 'testbucket'...
2024-05-17T16:03:04.9117202Z 
2024-05-17T16:03:04.9118942Z -------- Deployment Bucket Error --------
2024-05-17T16:03:04.9119755Z Service 's3' is not enabled. Please check your 'SERVICES' configuration variable.
```