### PR TITLE
send a slack notification on ci failure

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -49,3 +49,16 @@ jobs:
         DEBUG: 1
       timeout-minutes: 200
       run: make test-ci-all
+
+    - name: Send a Slack notification
+      if: failure() || github.event_name != 'pull_request'
+      uses: ravsamhq/notify-slack-action@v2
+      with:
+        status: ${{ job.status }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        notification_title: "{workflow} has {status_message}"
+        message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+        footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Workflow run>"
+        notify_when: "failure"
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR introduces an additional step in the CI workflow to send a Slack notification on `#notification-developer-hub` if the pipeline fails.