### PR TITLE
implement tgtm suggestions to apigw custom domain sample

### DIFF
--- a/apigw-custom-domain/Makefile
+++ b/apigw-custom-domain/Makefile
@@ -2,15 +2,28 @@ export AWS_ACCESS_KEY_ID ?= test
 export AWS_SECRET_ACCESS_KEY ?= test
 export AWS_DEFAULT_REGION ?= us-east-1
 
-
 usage:       ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
+precheck:    ## Check if all required prerequisites are installed
+	@command -v docker > /dev/null 2>&1 || { echo "Docker is not installed. Please install Docker and try again."; exit 1; }
+	@command -v node > /dev/null 2>&1 || { echo "Node.js is not installed. Please install Node.js and try again."; exit 1; }
+	@command -v aws > /dev/null 2>&1 || { echo "AWS CLI is not installed. Please install AWS CLI and try again."; exit 1; }
+	@command -v python > /dev/null 2>&1 || { echo "Python is not installed. Please install Python and try again."; exit 1; }
+	@command -v openssl > /dev/null 2>&1 || { echo "OpenSSL is not installed. Please install OpenSSL and try again."; exit 1; }
+	@echo "All required prerequisites are available."
+
 install:     ## Install dependencies
-	@npm install
 	@which serverless || npm install -g serverless
 	@which localstack || pip install localstack
 	@which awslocal || pip install awscli-local
+	@if [ ! -d "node_modules" ]; then \
+		echo "node_modules not found. Running npm install..."; \
+		npm install; \
+	else \
+		echo "node_modules already installed."; \
+	fi
+	@echo "All required dependencies are available."
 
 cert:        ## Create test SSL certificate
 	mkdir -p sslcert
@@ -22,37 +35,24 @@ cert:        ## Create test SSL certificate
 		openssl x509 -req -in ssl.csr -CAcreateserial -out server.crt -sha256 -CAkey rootCA.key -CA rootCA.pem
 
 run:         ## Deploy the app locally and run an API GW test invocation
-		echo "Generating and importing test SSL certificate to ACM for Route53 domain test.example.com"; \
-		make cert; \
-		echo "Importing local test certificate into ACM API ..."; \
-		awslocal acm import-certificate --certificate fileb://sslcert/server.crt --private-key fileb://sslcert/ssl.key && \
-		echo "Creating Route53 hosted zone for test domain 'test.example.com' ..."; \
-		awslocal route53 create-hosted-zone --name test.example.com --caller-reference r1 && \
-		echo "Deploying Serverless app to local environment"; \
-		SLS_DEBUG=1 npm run deploy && \
-		echo "Serverless app successfully deployed. Now trying to invoke the API Gateway endpoints with custom domains." && \
-		echo && echo "Invoking endpoint 1: http://test.example.com:4566/hello" && \
-		response1=`curl -H 'Host: test.example.com' http://localhost:4566/hello` && \
-		../assert "$$response1" = "hello world" && \
-		echo && echo && echo "Invoking endpoint 2: http://test.example.com:4566/goodbye" && \
-		response2=`curl -H 'Host: test.example.com' http://localhost:4566/goodbye` && \
-		../assert "$$response2" = "goodbye"
+	./run.sh --ci
 
-start:
+start:       ## Start LocalStack
 	localstack start -d
 
-stop:
+stop:        ## Stop LocalStack
 	@echo
 	localstack stop
-ready:
+
+ready:       ## Wait until LocalStack is ready
 	@echo Waiting on the LocalStack container...
 	@localstack wait -t 30 && echo Localstack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
 
-logs:
+logs:        ## Retrieve LocalStack logs
 	@localstack logs > logs.txt
 
-test-ci:
-	make start install ready run; return_code=`echo $$?`;\
+test-ci:     ## Run CI tests
+	make precheck start install ready run; return_code=`echo $$?`;\
 	make logs; make stop; exit $$return_code;
 
-.PHONY: usage install run cert ready stop logs test-ci
+.PHONY: usage precheck install run cert start stop ready logs test-ci

--- a/apigw-custom-domain/README.md
+++ b/apigw-custom-domain/README.md
@@ -1,69 +1,68 @@
-# LocalStack Demo: API Gateway with Custom Domains
+# API Gateway with Custom Domains
 
-Simple demo application illustrating API Gateway (v2) endpoints using custom domain names (via Route53, ACM), deployed locally in LocalStack using the Serverless framework.
+[![Makefile CI](https://github.com/localstack-samples/localstack-pro-samples/actions/workflows/makefile.yml/badge.svg)](https://github.com/localstack-samples/localstack-pro-samples/actions/workflows/makefile.yml)
+
+| Key          | Value                             |
+| ------------ | --------------------------------- |
+| Environment  | LocalStack                        |
+| Services     | API Gateway, Lambda, Route53, ACM |
+| Integrations | Serverless Framework              |
+| Categories   | Serverless; REST API              |
+| Level        | Beginner                          |
+
+## Introduction
+
+A demo application showcasing API Gateway (v2) endpoints with custom domain names configured through Route53 and ACM, deployed locally using LocalStack and the Serverless framework. For more details, refer to the [documentation](https://docs.localstack.cloud/user-guide/aws/apigateway/#custom-domain-names-with-api-gateway).
 
 ## Prerequisites
 
-* LocalStack
+* [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli) with [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/)
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) with [`awslocal` wrapper script](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal)
+* [Node.js 18.x](https://nodejs.org/en/download/package-manager) with `npm`
+* [Serverless Framework](https://www.serverless.com/framework/docs/getting-started) 3.x
 * Docker
-* Node.js / `npm`
-* `make`
+* `openssl` & `make`
 
-## Installing
+You can run `make check` to verify that all dependencies are installed.
 
-To install the dependencies:
-```
+## Installation
+
+Run the following command to install the necessary dependencies:
+
+```bash
 make install
 ```
 
-## Running
+## Start LocalStack
 
-Make sure that LocalStack is started:
-```
+To start LocalStack, run the following command:
+
+```bash
 LOCALSTACK_AUTH_TOKEN=... DEBUG=1 localstack start
 ```
 
-Deploy the app locally and run a test invocation via:
+## Deploy the Application
+
+Deploy the application locally using the Serverless framework:
+
 ```
-make run
+./run.sh
 ```
 
-The script first generates an SSL certificate for local testing (in case the `openssl` command is not available, it will use an existing, predefined certificate), and then adds it to Amazon Certificate Manager (ACM), and finally creates a Route53 hosted zone for the domain name `test.example.com`:
-```
-Generating a 2048 bit RSA private key
-...
-subject=/CN=test.example.com
-...
-Importing local test certificate into ACM API ...
-{
-    "CertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/9cbc69d6-abf9-412e-9e2b-36f99fcbf251"
-}
-Creating Route53 hosted zone for test domain 'test.example.com' ...
-{
-    "HostedZone": {
-        "Id": "/hostedzone/SU1TPRNX6CL3OE0",
-        "Name": "test.example.com.",
-        ...
+The script initially generates an SSL certificate for local testing. If the `openssl` command is unavailable, it uses an existing predefined certificate. The script then adds the certificate to Amazon Certificate Manager (ACM) and creates a Route53 hosted zone for the domain name `test.example.com`.
+
+Next, you will see the deployment logs of the Serverless application, with details displayed in the output section towards the bottom. The script then showcases the API Gateway endpoints and the custom domain name configuration, along with sample commands to invoke the deployed endpoints.
+
+```bash
+Serverless app successfully deployed.
+Now trying to invoke the API Gateway endpoints with custom domains.
+Sample command to invoke endpoint 1:
+curl -H 'Host: test.example.com' http://localhost:4566/hello
+Sample command to invoke endpoint 2:
+curl -H 'Host: test.example.com' http://localhost:4566/goodbye
 ```
 
-Next, you should see some output with the deployment logs of the Serverless application, and some details in the output section towards the bottom:
-```
-...
-Serverless Domain Manager: Info: Created API mapping '(none)' for test.example.com
-Serverless Domain Manager: Summary: Distribution Domain Name
-Serverless Domain Manager:    Domain Name: test.example.com
-Serverless Domain Manager:    Target Domain: test.example.com
-Serverless Domain Manager:    Hosted Zone Id: Z2FDTNDATAQYW2
-```
-
-Finally, the script runs two invocations of the new API GW API deployed under the custom domain name `test.example.com`:
-```
-Invoking endpoint 1: http://test.example.com:4566/hello
-...
-
-Invoking endpoint 2: http://test.example.com:4566/goodbye
-...
-```
+Under the hood, the Serverless framework uses the [`serverless-localstack`](https://github.com/localstack/serverless-localstack) plugin to deploy the application to LocalStack. The plugin is configured in the `serverless.yml` file to use the LocalStack endpoint and the custom domain name.
 
 ## License
 

--- a/apigw-custom-domain/run.sh
+++ b/apigw-custom-domain/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function deploy_app() {
+  echo "Generating and importing test SSL certificate to ACM for Route53 domain test.example.com"
+  make cert
+
+  echo "Importing local test certificate into ACM API ..."
+  awslocal acm import-certificate --certificate fileb://sslcert/server.crt --private-key fileb://sslcert/ssl.key
+
+  echo "Creating Route53 hosted zone for test domain 'test.example.com' ..."
+  awslocal route53 create-hosted-zone --name test.example.com --caller-reference r1
+
+  echo "Deploying Serverless app to local environment"
+  SLS_DEBUG=1 npm run deploy
+
+  echo "Serverless app successfully deployed."
+}
+
+function invoke_endpoints() {
+  echo "Invoking endpoint 1: http://test.example.com:4566/hello"
+  response1=$(curl -H 'Host: test.example.com' http://localhost:4566/hello)
+  ../assert "$response1" = "hello world"
+
+  echo "Invoking endpoint 2: http://test.example.com:4566/goodbye"
+  response2=$(curl -H 'Host: test.example.com' http://localhost:4566/goodbye)
+  ../assert "$response2" = "goodbye"
+}
+
+deploy_app
+
+if [[ "$1" == "--ci" ]]; then
+  invoke_endpoints
+else
+  echo "Now trying to invoke the API Gateway endpoints with custom domains."
+  echo "Sample command to invoke endpoint 1:"
+  echo "curl -H 'Host: test.example.com' http://localhost:4566/hello"
+  echo "Sample command to invoke endpoint 2:"
+  echo "curl -H 'Host: test.example.com' http://localhost:4566/goodbye"
+fi

--- a/apigw-custom-domain/serverless.yml
+++ b/apigw-custom-domain/serverless.yml
@@ -2,9 +2,9 @@ service: sls-apigw-domain
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   stage: local
-  region: ${env:AWS_DEFAULT_REGION, 'us-east-1'}
+  region: us-east-1
 
 custom:
   customDomain:


### PR DESCRIPTION
This PR:

-   Adds a passing CI badge to the sample.
-   Ensures the latest dependencies are used, except for the Serverless framework.
-   Adds a `precheck` target to the Makefile to ensure prerequisites are available.
-   Conceptualizes deployment and testing in a `run.sh` script with a `--ci` flag for smoke tests.
-   Updates the Node runtime to 18.x since newer runtimes (like 20.x) are locked behind a paywall.

Overall, this PR serves as a testbed to reach an agreement with TGTM, Support, and Engineering on establishing standard consistency across the sample. Please provide suggestions or thoughts to improve this further! :) 