### PR TITLE
remove LAMBDA_REMOTE_DOCKER configuration from README and docker-compose files

### DIFF
--- a/lambda-mounting-and-debugging/javascript/README.md
+++ b/lambda-mounting-and-debugging/javascript/README.md
@@ -29,7 +29,6 @@ Alternatively, you can use the following `localstack` CLI configuration:
 
 ```sh
 LAMBDA_DOCKER_FLAGS='-e NODE_OPTIONS=--inspect-brk=0.0.0.0:9229 -p 9229:9229' \
-    LAMBDA_REMOTE_DOCKER=0 \
     localstack start -d
 ```
 

--- a/lambda-mounting-and-debugging/javascript/docker-compose.yml
+++ b/lambda-mounting-and-debugging/javascript/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
       - DEBUG=1
-      - LAMBDA_REMOTE_DOCKER=0
       - LAMBDA_DOCKER_FLAGS=-e NODE_OPTIONS=--inspect-brk=0.0.0.0:9229 -p 9229:9229
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR-}
       - DOCKER_HOST=unix:///var/run/docker.sock

--- a/lambda-mounting-and-debugging/python/README.md
+++ b/lambda-mounting-and-debugging/python/README.md
@@ -21,12 +21,9 @@ make install
 Make sure that LocalStack is started with the following configuration:
 ```
 LOCALSTACK_AUTH_TOKEN=... \
-    LAMBDA_REMOTE_DOCKER=0 \
     LAMBDA_DOCKER_FLAGS='-p 19891:19891' \
     DEBUG=1 localstack start
 ```
-
-Please note that `LAMBDA_REMOTE_DOCKER=0` needs to be configured in order to properly run the sample app (required for local Docker volume mounts).
 
 The config option `LAMBDA_DOCKER_FLAGS='-p 19891:19891'` defines a Docker flag that exposes port `19891` for debugging the Lambda handler code that will run inside the container.
 


### PR DESCRIPTION
Remove the deprecated `LAMBDA_REMOTE_DOCKER` configuration from README and docker-compose files.

https://docs.localstack.cloud/references/configuration/#legacy

LAMBDA_REMOTE_DOCKER | 3.0.0 |   | determines whether Lambda code is copied or mounted into containers.Removed in new provider because zip file copying is used by default and hot reloading automatically configures mounting.
-- | -- | -- | --